### PR TITLE
Better appliance of the ALv2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,202 @@
-Copyright 2012 Mirko Caserta
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this software except in compliance with the License.
-You may obtain a copy of the License at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Spring Crypto Utils
+Copyright 2012 Mirko Caserta
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
@@ -95,6 +110,19 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>${basedir}</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE</include>
+                    <include>NOTICE</include>
+                </includes>
+            </resource>
+        </resources>
         <extensions>
             <extension>
                 <groupId>org.jvnet.wagon-svn</groupId>

--- a/src/main/java/com/springcryptoutils/core/certificate/CertificateChooserByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/certificate/CertificateChooserByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/certificate/CertificateException.java
+++ b/src/main/java/com/springcryptoutils/core/certificate/CertificateException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/certificate/CertificateFactoryBean.java
+++ b/src/main/java/com/springcryptoutils/core/certificate/CertificateFactoryBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 import org.springframework.beans.factory.FactoryBean;

--- a/src/main/java/com/springcryptoutils/core/certificate/CertificateRegistryByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/certificate/CertificateRegistryByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/main/java/com/springcryptoutils/core/certificate/CertificateRegistryByAliasImpl.java
+++ b/src/main/java/com/springcryptoutils/core/certificate/CertificateRegistryByAliasImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/main/java/com/springcryptoutils/core/certificate/package-info.java
+++ b/src/main/java/com/springcryptoutils/core/certificate/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes used to load cryptographic certificates
  * and map references to them.

--- a/src/main/java/com/springcryptoutils/core/cipher/Mode.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/Mode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/AsymmetricEncryptionException.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/AsymmetricEncryptionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCipherer.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCipherer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import java.security.Key;
@@ -11,7 +26,7 @@ import com.springcryptoutils.core.cipher.Mode;
 /**
  * The default implementation for performing asymmetric encryption/decryption
  * with base64 encoded strings and a static key.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
@@ -24,7 +39,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 
 	/**
 	 * The asymmetric key algorithm. The default is RSA.
-	 * 
+	 *
 	 * @param algorithm the asymmetric key algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -34,7 +49,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 	/**
 	 * The charset used when a message must be converted into a raw byte array.
 	 * Default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name
 	 */
 	public void setCharsetName(String charsetName) {
@@ -44,7 +59,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -53,7 +68,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -62,7 +77,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 
 	/**
 	 * Sets the encryption key.
-	 * 
+	 *
 	 * @param key the encryption key
 	 */
 	public void setKey(Key key) {
@@ -71,7 +86,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 
 	/**
 	 * Encrypts/decrypts a message based on the underlying mode of operation.
-	 * 
+	 *
 	 * @param message if in encryption mode, the clear-text message, otherwise
 	 *        the base64 encoded message to decrypt
 	 * @return if in encryption mode, the base64 encoded encrypted message,

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyId.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyId.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import java.security.Key;
@@ -12,7 +27,7 @@ import com.springcryptoutils.core.cipher.Mode;
 /**
  * The default implementation for performing asymmetric encryption/decryption
  * with base64 encoded strings and keys which are mapped with a logical name.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedCiphererWithChooserByKeyIdImpl implements Base64EncodedCiphererWithChooserByKeyId {
@@ -26,7 +41,7 @@ public class Base64EncodedCiphererWithChooserByKeyIdImpl implements Base64Encode
 
 	/**
 	 * The asymmetric key algorithm. The default is RSA.
-	 * 
+	 *
 	 * @param algorithm the asymmetric key algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -36,7 +51,7 @@ public class Base64EncodedCiphererWithChooserByKeyIdImpl implements Base64Encode
 	/**
 	 * The charset used when a message must be converted into a raw byte array.
 	 * Default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name
 	 */
 	public void setCharsetName(String charsetName) {
@@ -46,7 +61,7 @@ public class Base64EncodedCiphererWithChooserByKeyIdImpl implements Base64Encode
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -55,7 +70,7 @@ public class Base64EncodedCiphererWithChooserByKeyIdImpl implements Base64Encode
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -65,7 +80,7 @@ public class Base64EncodedCiphererWithChooserByKeyIdImpl implements Base64Encode
 	/**
 	 * Sets the map of keys. The map key is a string representing the logical
 	 * name of the key (the keyId).
-	 * 
+	 *
 	 * @param keyMap the key map
 	 */
 	public void setKeyMap(Map<String, Key> keyMap) {
@@ -74,7 +89,7 @@ public class Base64EncodedCiphererWithChooserByKeyIdImpl implements Base64Encode
 
 	/**
 	 * Encrypts/decrypts a message based on the underlying mode of operation.
-	 * 
+	 *
 	 * @param keyId the key id
 	 * @param message if in encryption mode, the clear-text message, otherwise
 	 *        the base64 encoded message to decrypt

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Cipherer.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/Cipherer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/CiphererImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/CiphererImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import java.security.Key;
@@ -9,7 +24,7 @@ import com.springcryptoutils.core.cipher.Mode;
 /**
  * The default implementation for performing asymmetric encryption/decryption
  * with a static key.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class CiphererImpl implements Cipherer {
@@ -21,7 +36,7 @@ public class CiphererImpl implements Cipherer {
 
 	/**
 	 * The asymmetric key algorithm. The default is RSA.
-	 * 
+	 *
 	 * @param algorithm the asymmetric key algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -31,7 +46,7 @@ public class CiphererImpl implements Cipherer {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -40,7 +55,7 @@ public class CiphererImpl implements Cipherer {
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -49,7 +64,7 @@ public class CiphererImpl implements Cipherer {
 
 	/**
 	 * Sets the encryption key.
-	 * 
+	 *
 	 * @param key the encryption key
 	 */
 	public void setKey(Key key) {
@@ -58,7 +73,7 @@ public class CiphererImpl implements Cipherer {
 
 	/**
 	 * Encrypts/decrypts a message based on the underlying mode of operation.
-	 * 
+	 *
 	 * @param message if in encryption mode, the clear-text message, otherwise
 	 *        the message to decrypt
 	 * @return if in encryption mode, the encrypted message, otherwise the

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyId.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyId.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import java.security.Key;
@@ -10,7 +25,7 @@ import com.springcryptoutils.core.cipher.Mode;
 /**
  * The default implementation for performing asymmetric encryption/decryption
  * with keys which are mapped with a logical name.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class CiphererWithChooserByKeyIdImpl implements CiphererWithChooserByKeyId {
@@ -23,7 +38,7 @@ public class CiphererWithChooserByKeyIdImpl implements CiphererWithChooserByKeyI
 
 	/**
 	 * The asymmetric key algorithm. The default is RSA.
-	 * 
+	 *
 	 * @param algorithm the asymmetric key algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -33,7 +48,7 @@ public class CiphererWithChooserByKeyIdImpl implements CiphererWithChooserByKeyI
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -42,7 +57,7 @@ public class CiphererWithChooserByKeyIdImpl implements CiphererWithChooserByKeyI
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -52,7 +67,7 @@ public class CiphererWithChooserByKeyIdImpl implements CiphererWithChooserByKeyI
 	/**
 	 * Sets the map of keys. The map key is a string representing the logical
 	 * name of the key (the keyId).
-	 * 
+	 *
 	 * @param keyMap the key map
 	 */
 	public void setKeyMap(Map<String, Key> keyMap) {
@@ -61,7 +76,7 @@ public class CiphererWithChooserByKeyIdImpl implements CiphererWithChooserByKeyI
 
 	/**
 	 * Encrypts/decrypts a message based on the underlying mode of operation.
-	 * 
+	 *
 	 * @param keyId the key id
 	 * @param message if in encryption mode, the clear-text message, otherwise
 	 *        the message to decrypt

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCipherer.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCipherer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import javax.crypto.Cipher;
@@ -11,7 +26,7 @@ import com.springcryptoutils.core.cipher.Mode;
 /**
  * Default implementation for performing symmetric encryption with strings
  * containing base64 encoded versions of raw byte arrays.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
@@ -25,7 +40,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 
 	/**
 	 * The symmetric key algorithm. The default is DESede (triple DES).
-	 * 
+	 *
 	 * @param keyAlgorithm the symmetric key algorithm
 	 */
 	public void setKeyAlgorithm(String keyAlgorithm) {
@@ -35,7 +50,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 	/**
 	 * The cipher algorithm. The default is DESede/CBC/PKCS5Padding (triple DES
 	 * with Cipher Block Chaining and PKCS 5 padding).
-	 * 
+	 *
 	 * @param cipherAlgorithm the cipher algorithm
 	 */
 	public void setCipherAlgorithm(String cipherAlgorithm) {
@@ -45,7 +60,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -55,7 +70,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -64,7 +79,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -76,7 +91,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 	 * formatted so it's easier to read? This may not work well with some base64
 	 * decoders which don't accept whitespace in the input so the default is
 	 * false.
-	 * 
+	 *
 	 * @param chunkOutput should the output be formatted?
 	 */
 	public void setChunkOutput(boolean chunkOutput) {
@@ -86,7 +101,7 @@ public class Base64EncodedCiphererImpl implements Base64EncodedCipherer {
 	/**
 	 * Encrypts or decrypts a message. The encryption/decryption mode depends on
 	 * the configuration of the mode parameter.
-	 * 
+	 *
 	 * @param key a base64 encoded version of the symmetric key
 	 * @param initializationVector a base64 encoded version of the
 	 *        initialization vector

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKey.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKey.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import javax.crypto.Cipher;
@@ -12,7 +27,7 @@ import com.springcryptoutils.core.cipher.Mode;
 /**
  * The default implementation for performing symmetric encryption/decryption
  * using base64 encoded versions of raw byte arrays and a static key.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiphererWithStaticKey, InitializingBean {
@@ -29,7 +44,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 
 	/**
 	 * The symmetric key algorithm. The default is DESede (triple DES).
-	 * 
+	 *
 	 * @param keyAlgorithm the symmetric key algorithm
 	 */
 	public void setKeyAlgorithm(String keyAlgorithm) {
@@ -39,7 +54,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 	/**
 	 * The cipher algorithm. The default is DESede/CBC/PKCS5Padding (triple DES
 	 * with Cipher Block Chaining and PKCS 5 padding).
-	 * 
+	 *
 	 * @param cipherAlgorithm the cipher algorithm
 	 */
 	public void setCipherAlgorithm(String cipherAlgorithm) {
@@ -49,7 +64,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -59,7 +74,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -68,7 +83,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -80,7 +95,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 	 * formatted so it's easier to read? This may not work well with some base64
 	 * decoders which don't accept whitespace in the input so the default is
 	 * false.
-	 * 
+	 *
 	 * @param chunkOutput should the output be formatted?
 	 */
 	public void setChunkOutput(boolean chunkOutput) {
@@ -90,7 +105,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 	/**
 	 * A base64 encoded representation of the raw byte array containing the
 	 * initialization vector.
-	 * 
+	 *
 	 * @param initializationVector the initialization vector
 	 */
 	public void setInitializationVector(String initializationVector) {
@@ -100,7 +115,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 	/**
 	 * A base64 encoded representation of the raw byte array containing the
 	 * cryptographic key.
-	 * 
+	 *
 	 * @param key the cryptographic key
 	 */
 	public void setKey(String key) {
@@ -109,7 +124,7 @@ public class Base64EncodedCiphererWithStaticKeyImpl implements Base64EncodedCiph
 
 	/**
 	 * Encrypts/decrypts a message using the underlying symmetric key and mode.
-	 * 
+	 *
 	 * @param message if in encryption mode, the clear-text message to encrypt,
 	 *        otherwise a base64 encoded version of the raw byte array
 	 *        containing the message to decrypt

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGenerator.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import java.security.NoSuchAlgorithmException;
@@ -9,7 +24,7 @@ import org.springframework.beans.factory.InitializingBean;
 /**
  * The default implementation for generating base64 encoded versions of
  * symmetric encryption keys.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedKeyGeneratorImpl implements Base64EncodedKeyGenerator, InitializingBean {
@@ -23,7 +38,7 @@ public class Base64EncodedKeyGeneratorImpl implements Base64EncodedKeyGenerator,
 
 	/**
 	 * Sets the key algorithm. Default is DESede (triple DES).
-	 * 
+	 *
 	 * @param algorithm the algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -33,7 +48,7 @@ public class Base64EncodedKeyGeneratorImpl implements Base64EncodedKeyGenerator,
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -44,7 +59,7 @@ public class Base64EncodedKeyGeneratorImpl implements Base64EncodedKeyGenerator,
 	 * If the base64 encoded version of the generated key is wider than the
 	 * standard console width, should it be formatted so it's easier to read?
 	 * The default is false.
-	 * 
+	 *
 	 * @param chunkOutput to chunk or not to chunk?
 	 */
 	public void setChunkOutput(boolean chunkOutput) {
@@ -54,7 +69,7 @@ public class Base64EncodedKeyGeneratorImpl implements Base64EncodedKeyGenerator,
 	/**
 	 * Generates a base64 encoded version of a newly instanced symmetric
 	 * encryption key.
-	 * 
+	 *
 	 * @return the base64 encoded version of a newly instanced symmetric
 	 *         encryption key
 	 */

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/Cipherer.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/Cipherer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/CiphererImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/CiphererImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import javax.crypto.Cipher;
@@ -8,7 +23,7 @@ import com.springcryptoutils.core.cipher.Mode;
 
 /**
  * The default implementation for performing symmetric encryption/decryption.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class CiphererImpl implements Cipherer {
@@ -20,7 +35,7 @@ public class CiphererImpl implements Cipherer {
 
 	/**
 	 * The symmetric key algorithm. The default is DESede (triple DES).
-	 * 
+	 *
 	 * @param keyAlgorithm the symmetric key algorithm
 	 */
 	public void setKeyAlgorithm(String keyAlgorithm) {
@@ -30,7 +45,7 @@ public class CiphererImpl implements Cipherer {
 	/**
 	 * The cipher algorithm. The default is DESede/CBC/PKCS5Padding (triple DES
 	 * with Cipher Block Chaining and PKCS 5 padding).
-	 * 
+	 *
 	 * @param cipherAlgorithm the cipher algorithm
 	 */
 	public void setCipherAlgorithm(String cipherAlgorithm) {
@@ -40,7 +55,7 @@ public class CiphererImpl implements Cipherer {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -49,7 +64,7 @@ public class CiphererImpl implements Cipherer {
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -58,7 +73,7 @@ public class CiphererImpl implements Cipherer {
 
 	/**
 	 * Encrypts/decrypts a message based on the underlying mode of operation.
-	 * 
+	 *
 	 * @param key the encryption key
 	 * @param initializationVector the initialization vector
 	 * @param message if in encryption mode, the clear-text message, otherwise

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKey.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKey.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import java.io.UnsupportedEncodingException;
@@ -14,7 +29,7 @@ import com.springcryptoutils.core.cipher.Mode;
 /**
  * The default implementation for performing symmetric encryption/decryption
  * using a static key.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, InitializingBean {
@@ -29,7 +44,7 @@ public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, Initial
 
 	/**
 	 * The symmetric key algorithm. The default is DESede (triple DES).
-	 * 
+	 *
 	 * @param keyAlgorithm the symmetric key algorithm
 	 */
 	public void setKeyAlgorithm(String keyAlgorithm) {
@@ -39,7 +54,7 @@ public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, Initial
 	/**
 	 * The cipher algorithm. The default is DESede/CBC/PKCS5Padding (triple DES
 	 * with Cipher Block Chaining and PKCS 5 padding).
-	 * 
+	 *
 	 * @param cipherAlgorithm the cipher algorithm
 	 */
 	public void setCipherAlgorithm(String cipherAlgorithm) {
@@ -49,7 +64,7 @@ public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, Initial
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -58,7 +73,7 @@ public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, Initial
 
 	/**
 	 * Sets the encryption/decryption mode.
-	 * 
+	 *
 	 * @param mode the encryption/decryption mode
 	 */
 	public void setMode(Mode mode) {
@@ -68,7 +83,7 @@ public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, Initial
 	/**
 	 * A base64 encoded representation of the raw byte array containing the
 	 * initialization vector.
-	 * 
+	 *
 	 * @param initializationVector the initialization vector
 	 * @throws SymmetricEncryptionException on runtime errors
 	 */
@@ -83,7 +98,7 @@ public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, Initial
 	/**
 	 * A base64 encoded representation of the raw byte array containing the
 	 * cryptographic key.
-	 * 
+	 *
 	 * @param key the cryptographic key
 	 */
 	public void setKey(String key) {
@@ -92,7 +107,7 @@ public class CiphererWithStaticKeyImpl implements CiphererWithStaticKey, Initial
 
 	/**
 	 * Encrypts/decrypts a message based on the underlying mode of operation.
-	 * 
+	 *
 	 * @param message if in encryption mode, the clear-text message, otherwise
 	 *        the message to decrypt
 	 * @return if in encryption mode, the encrypted message, otherwise the

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/KeyGenerator.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/KeyGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImpl.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import java.security.NoSuchAlgorithmException;
@@ -8,7 +23,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 /**
  * The default implementation for generating symmetric encryption keys.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class KeyGeneratorImpl implements KeyGenerator, InitializingBean {
@@ -20,7 +35,7 @@ public class KeyGeneratorImpl implements KeyGenerator, InitializingBean {
 
 	/**
 	 * Sets the key algorithm. Default is DESede (triple DES).
-	 * 
+	 *
 	 * @param algorithm the algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -30,7 +45,7 @@ public class KeyGeneratorImpl implements KeyGenerator, InitializingBean {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -39,7 +54,7 @@ public class KeyGeneratorImpl implements KeyGenerator, InitializingBean {
 
 	/**
 	 * Generates a new symmetric encryption key.
-	 * 
+	 *
 	 * @return the new symmetric encryption key
 	 */
 	public byte[] generate() {

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/SymmetricEncryptionException.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/SymmetricEncryptionException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/cipher/symmetric/package-info.java
+++ b/src/main/java/com/springcryptoutils/core/cipher/symmetric/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes used to do symmetric encryption.
  *

--- a/src/main/java/com/springcryptoutils/core/digest/DigestException.java
+++ b/src/main/java/com/springcryptoutils/core/digest/DigestException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.digest;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/digest/Digester.java
+++ b/src/main/java/com/springcryptoutils/core/digest/Digester.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.digest;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/digest/DigesterImpl.java
+++ b/src/main/java/com/springcryptoutils/core/digest/DigesterImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.digest;
 
 import java.io.UnsupportedEncodingException;
@@ -11,7 +26,7 @@ import org.springframework.beans.factory.InitializingBean;
 
 /**
  * Default implementation of the message digester.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class DigesterImpl implements Digester, InitializingBean {
@@ -35,7 +50,7 @@ public class DigesterImpl implements Digester, InitializingBean {
 
 	/**
 	 * Sets the digest algorithm. Default is SHA1.
-	 * 
+	 *
 	 * @param algorithm the digest algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -44,7 +59,7 @@ public class DigesterImpl implements Digester, InitializingBean {
 
 	/**
 	 * Sets the output mode. Default is HEX.
-	 * 
+	 *
 	 * @param outputMode the output mode
 	 */
 	public void setOutputMode(OutputMode outputMode) {
@@ -54,7 +69,7 @@ public class DigesterImpl implements Digester, InitializingBean {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -64,7 +79,7 @@ public class DigesterImpl implements Digester, InitializingBean {
 	/**
 	 * Sets the charset to use when converting the message into a raw byte
 	 * array.
-	 * 
+	 *
 	 * @param charsetName the charset name
 	 */
 	public void setCharsetName(String charsetName) {
@@ -74,7 +89,7 @@ public class DigesterImpl implements Digester, InitializingBean {
 	/**
 	 * Returns the message digest. The representation of the message digest
 	 * depends on the outputMode property.
-	 * 
+	 *
 	 * @param message the message
 	 * @return the message digest
 	 * @see #setOutputMode(OutputMode)
@@ -102,7 +117,7 @@ public class DigesterImpl implements Digester, InitializingBean {
 
 	/**
 	 * Returns the message digest in raw bytes format.
-	 * 
+	 *
 	 * @param message the message
 	 * @return the message digest
 	 */

--- a/src/main/java/com/springcryptoutils/core/key/PrivateKeyChooserByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/key/PrivateKeyChooserByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/key/PrivateKeyException.java
+++ b/src/main/java/com/springcryptoutils/core/key/PrivateKeyException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/key/PrivateKeyFactoryBean.java
+++ b/src/main/java/com/springcryptoutils/core/key/PrivateKeyFactoryBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.springframework.beans.factory.FactoryBean;

--- a/src/main/java/com/springcryptoutils/core/key/PrivateKeyRegistryByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/key/PrivateKeyRegistryByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/main/java/com/springcryptoutils/core/key/PrivateKeyRegistryByAliasImpl.java
+++ b/src/main/java/com/springcryptoutils/core/key/PrivateKeyRegistryByAliasImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/main/java/com/springcryptoutils/core/key/PublicKeyChooserByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/key/PublicKeyChooserByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/key/PublicKeyException.java
+++ b/src/main/java/com/springcryptoutils/core/key/PublicKeyException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/key/PublicKeyFactoryBean.java
+++ b/src/main/java/com/springcryptoutils/core/key/PublicKeyFactoryBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.springframework.beans.factory.FactoryBean;

--- a/src/main/java/com/springcryptoutils/core/key/PublicKeyRegistryByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/key/PublicKeyRegistryByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/main/java/com/springcryptoutils/core/key/PublicKeyRegistryByAliasImpl.java
+++ b/src/main/java/com/springcryptoutils/core/key/PublicKeyRegistryByAliasImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/main/java/com/springcryptoutils/core/key/SecretKeyException.java
+++ b/src/main/java/com/springcryptoutils/core/key/SecretKeyException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/key/SecretKeyFactoryBean.java
+++ b/src/main/java/com/springcryptoutils/core/key/SecretKeyFactoryBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.springframework.beans.factory.FactoryBean;

--- a/src/main/java/com/springcryptoutils/core/key/package-info.java
+++ b/src/main/java/com/springcryptoutils/core/key/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes used to load cryptographic keys
  * and map references to them.

--- a/src/main/java/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBean.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import java.io.ByteArrayInputStream;
@@ -15,7 +30,7 @@ import org.springframework.beans.factory.InitializingBean;
 /**
  * A spring bean factory for instancing KeyStore objects from a base64 encoded
  * keystore file.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedKeyStoreFactoryBean implements FactoryBean,
@@ -30,7 +45,7 @@ public class Base64EncodedKeyStoreFactoryBean implements FactoryBean,
 
     /**
      * Sets the BASE64 encoded version of the keystore file.
-     * 
+     *
      * @param base64EncodedKeyStoreFile
      *            the BASE64 encoded version of the keystore file
      */
@@ -40,7 +55,7 @@ public class Base64EncodedKeyStoreFactoryBean implements FactoryBean,
 
     /**
      * Sets the keystore password.
-     * 
+     *
      * @param password
      *            the keystore password
      */
@@ -50,7 +65,7 @@ public class Base64EncodedKeyStoreFactoryBean implements FactoryBean,
 
     /**
      * Sets the keystore type (defaults to JKS).
-     * 
+     *
      * @param type
      *            the keystore type (defaults to JKS)
      */
@@ -61,7 +76,7 @@ public class Base64EncodedKeyStoreFactoryBean implements FactoryBean,
     /**
      * Sets the provider name of the specific implementation requested (e.g.,
      * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-     * 
+     *
      * @param provider
      *            the provider to set
      */

--- a/src/main/java/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBean.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import org.springframework.beans.factory.FactoryBean;
@@ -39,7 +54,7 @@ public class DefaultKeyStoreFactoryBean implements FactoryBean, InitializingBean
 
     public void afterPropertiesSet() throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException, InitializationException {
         final String keyStoreLocation = System.getProperty("javax.net.ssl.keyStore");
-        
+
         if (keyStoreLocation == null || keyStoreLocation.trim().length() == 0) {
             throw new InitializationException("no value was specified for the system property: javax.net.ssl.keyStore");
         }

--- a/src/main/java/com/springcryptoutils/core/keystore/InitializationException.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/InitializationException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 public class InitializationException extends Exception {

--- a/src/main/java/com/springcryptoutils/core/keystore/KeyStoreChooser.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/KeyStoreChooser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/keystore/KeyStoreFactoryBean.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/KeyStoreFactoryBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import java.io.IOException;
@@ -13,7 +28,7 @@ import org.springframework.core.io.Resource;
 
 /**
  * A spring bean factory for instancing KeyStore objects.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class KeyStoreFactoryBean implements FactoryBean, InitializingBean {
@@ -27,7 +42,7 @@ public class KeyStoreFactoryBean implements FactoryBean, InitializingBean {
 
 	/**
 	 * Sets the keystore location.
-	 * 
+	 *
 	 * @param location the keystore location
 	 */
 	public void setLocation(Resource location) {
@@ -36,7 +51,7 @@ public class KeyStoreFactoryBean implements FactoryBean, InitializingBean {
 
 	/**
 	 * Sets the keystore password.
-	 * 
+	 *
 	 * @param password the keystore password
 	 */
 	public void setPassword(String password) {
@@ -45,7 +60,7 @@ public class KeyStoreFactoryBean implements FactoryBean, InitializingBean {
 
 	/**
 	 * Sets the keystore type (defaults to JKS).
-	 * 
+	 *
 	 * @param type the keystore type (defaults to JKS)
 	 */
 	public void setType(String type) {
@@ -55,7 +70,7 @@ public class KeyStoreFactoryBean implements FactoryBean, InitializingBean {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {

--- a/src/main/java/com/springcryptoutils/core/keystore/KeyStoreMapper.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/KeyStoreMapper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import java.security.KeyStore;

--- a/src/main/java/com/springcryptoutils/core/keystore/KeyStoreMapperImpl.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/KeyStoreMapperImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import java.security.KeyStore;

--- a/src/main/java/com/springcryptoutils/core/keystore/KeyStoreRegistry.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/KeyStoreRegistry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import java.security.KeyStore;

--- a/src/main/java/com/springcryptoutils/core/keystore/KeyStoreRegistryImpl.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/KeyStoreRegistryImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import java.security.KeyStore;

--- a/src/main/java/com/springcryptoutils/core/keystore/package-info.java
+++ b/src/main/java/com/springcryptoutils/core/keystore/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes used to load cryptographic keystores
  * and map references to them.

--- a/src/main/java/com/springcryptoutils/core/mac/Base64EncodedMac.java
+++ b/src/main/java/com/springcryptoutils/core/mac/Base64EncodedMac.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/mac/Base64EncodedMacImpl.java
+++ b/src/main/java/com/springcryptoutils/core/mac/Base64EncodedMacImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 import java.security.Key;
@@ -7,7 +22,7 @@ import org.apache.commons.codec.binary.Base64;
 /**
  * The default implementation for providing base64 encoded Message
  * Authentication Codes.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedMacImpl implements Base64EncodedMac {
@@ -16,7 +31,7 @@ public class Base64EncodedMacImpl implements Base64EncodedMac {
 
 	/**
 	 * The secret key for digesting the message.
-	 * 
+	 *
 	 * @param secretKey the secret key
 	 */
 	public void setSecretKey(Key secretKey) {
@@ -25,7 +40,7 @@ public class Base64EncodedMacImpl implements Base64EncodedMac {
 
 	/**
 	 * The algorithm. The default is HmacSHA1.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -35,7 +50,7 @@ public class Base64EncodedMacImpl implements Base64EncodedMac {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {

--- a/src/main/java/com/springcryptoutils/core/mac/Mac.java
+++ b/src/main/java/com/springcryptoutils/core/mac/Mac.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/mac/MacException.java
+++ b/src/main/java/com/springcryptoutils/core/mac/MacException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/com/springcryptoutils/core/mac/MacImpl.java
+++ b/src/main/java/com/springcryptoutils/core/mac/MacImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 import java.security.InvalidKeyException;
@@ -7,7 +22,7 @@ import java.security.NoSuchProviderException;
 
 /**
  * Default implementation for Message Authentication Codes.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class MacImpl implements Mac {
@@ -20,7 +35,7 @@ public class MacImpl implements Mac {
 
 	/**
 	 * The secret key for digesting the message.
-	 * 
+	 *
 	 * @param secretKey the secret key
 	 */
 	public void setSecretKey(Key secretKey) {
@@ -29,7 +44,7 @@ public class MacImpl implements Mac {
 
 	/**
 	 * The algorithm. The default is HmacSHA1.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -39,7 +54,7 @@ public class MacImpl implements Mac {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSigner.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSigner.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.io.UnsupportedEncodingException;
@@ -8,7 +23,7 @@ import org.apache.commons.codec.binary.Base64;
 /**
  * The default implementation for providing base64 encoded versions of digital
  * signatures.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedSignerImpl implements Base64EncodedSigner {
@@ -19,7 +34,7 @@ public class Base64EncodedSignerImpl implements Base64EncodedSigner {
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -28,7 +43,7 @@ public class Base64EncodedSignerImpl implements Base64EncodedSigner {
 
 	/**
 	 * The private key for signing the message.
-	 * 
+	 *
 	 * @param privateKey the private key
 	 */
 	public void setPrivateKey(PrivateKey privateKey) {
@@ -38,7 +53,7 @@ public class Base64EncodedSignerImpl implements Base64EncodedSigner {
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -48,7 +63,7 @@ public class Base64EncodedSignerImpl implements Base64EncodedSigner {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -57,7 +72,7 @@ public class Base64EncodedSignerImpl implements Base64EncodedSigner {
 
 	/**
 	 * Signs a message.
-	 * 
+	 *
 	 * @param message the message to sign
 	 * @return a base64 encoded version of the signature
 	 */

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChooserByPrivateKeyId.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChooserByPrivateKeyId.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChooserByPrivateKeyIdImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChooserByPrivateKeyIdImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PrivateKey;
@@ -8,7 +23,7 @@ import java.util.Map;
  * The default implementation for providing base64 encoded versions of digital
  * signatures where the private key is configured in the underlying mapping
  * using a logical name.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedSignerWithChooserByPrivateKeyIdImpl implements Base64EncodedSignerWithChooserByPrivateKeyId {
@@ -25,7 +40,7 @@ public class Base64EncodedSignerWithChooserByPrivateKeyIdImpl implements Base64E
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -35,7 +50,7 @@ public class Base64EncodedSignerWithChooserByPrivateKeyIdImpl implements Base64E
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -45,7 +60,7 @@ public class Base64EncodedSignerWithChooserByPrivateKeyIdImpl implements Base64E
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -55,7 +70,7 @@ public class Base64EncodedSignerWithChooserByPrivateKeyIdImpl implements Base64E
 	/**
 	 * The map of private keys where the map keys are logical names which must
 	 * match the privateKeyId parameter as specified in the sign method.
-	 * 
+	 *
 	 * @param privateKeyMap the private key map
 	 * @see #sign(String, String)
 	 */
@@ -65,7 +80,7 @@ public class Base64EncodedSignerWithChooserByPrivateKeyIdImpl implements Base64E
 
 	/**
 	 * Signs a message.
-	 * 
+	 *
 	 * @param privateKeyId the logical name of the private key as configured in
 	 *        the underlying mapping
 	 * @param message the message to sign

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChoosersByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChoosersByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PrivateKeyChooserByAlias;

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChoosersByAliasImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedSignerWithChoosersByAliasImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PrivateKey;
@@ -12,7 +27,7 @@ import com.springcryptoutils.core.keystore.KeyStoreChooser;
  * The default implementation for providing base64 encoded digital signatures
  * when the private key alias can be configured on the side of the user of this
  * interface.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedSignerWithChoosersByAliasImpl implements Base64EncodedSignerWithChoosersByAlias {
@@ -29,7 +44,7 @@ public class Base64EncodedSignerWithChoosersByAliasImpl implements Base64Encoded
 
 	/**
 	 * Sets the private key registry by alias.
-	 * 
+	 *
 	 * @param privateKeyRegistryByAlias the private key registry by alias
 	 */
 	public void setPrivateKeyRegistryByAlias(PrivateKeyRegistryByAlias privateKeyRegistryByAlias) {
@@ -38,7 +53,7 @@ public class Base64EncodedSignerWithChoosersByAliasImpl implements Base64Encoded
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -48,7 +63,7 @@ public class Base64EncodedSignerWithChoosersByAliasImpl implements Base64Encoded
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -58,7 +73,7 @@ public class Base64EncodedSignerWithChoosersByAliasImpl implements Base64Encoded
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -67,7 +82,7 @@ public class Base64EncodedSignerWithChoosersByAliasImpl implements Base64Encoded
 
 	/**
 	 * Signs a message.
-	 * 
+	 *
 	 * @param keyStoreChooser the keystore chooser
 	 * @param privateKeyChooserByAlias the private key chooser
 	 * @param message the message to sign

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifier.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.io.UnsupportedEncodingException;
@@ -8,7 +23,7 @@ import org.apache.commons.codec.binary.Base64;
 /**
  * The default implementation for verifying the authenticity of messages using
  * base64 encoded digital signatures.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedVerifierImpl implements Base64EncodedVerifier {
@@ -19,7 +34,7 @@ public class Base64EncodedVerifierImpl implements Base64EncodedVerifier {
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -28,7 +43,7 @@ public class Base64EncodedVerifierImpl implements Base64EncodedVerifier {
 
 	/**
 	 * The public key for verifying the message.
-	 * 
+	 *
 	 * @param publicKey the public key
 	 */
 	public void setPublicKey(PublicKey publicKey) {
@@ -38,7 +53,7 @@ public class Base64EncodedVerifierImpl implements Base64EncodedVerifier {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -48,7 +63,7 @@ public class Base64EncodedVerifierImpl implements Base64EncodedVerifier {
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -58,7 +73,7 @@ public class Base64EncodedVerifierImpl implements Base64EncodedVerifier {
 	/**
 	 * Verifies the authenticity of a message using a base64 encoded digital
 	 * signature.
-	 * 
+	 *
 	 * @param message the original message to verify
 	 * @param signature the base64 encoded digital signature
 	 * @return true if the original message is verified by the digital signature

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChooserByPublicKeyId.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChooserByPublicKeyId.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChooserByPublicKeyIdImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChooserByPublicKeyIdImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PublicKey;
@@ -8,7 +23,7 @@ import java.util.Map;
  * The default implementation for verifying the authenticity of messages using
  * base64 encoded digital signatures when the public key is configured in an
  * underlying mapping using a logical name.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedVerifierWithChooserByPublicKeyIdImpl implements Base64EncodedVerifierWithChooserByPublicKeyId {
@@ -26,7 +41,7 @@ public class Base64EncodedVerifierWithChooserByPublicKeyIdImpl implements Base64
 	/**
 	 * The map of public keys where the map keys are logical names which must
 	 * match the publicKeyId parameter as specified in the verify method.
-	 * 
+	 *
 	 * @param publicKeyMap the public key map
 	 * @see #verify(String, String, String)
 	 */
@@ -36,7 +51,7 @@ public class Base64EncodedVerifierWithChooserByPublicKeyIdImpl implements Base64
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -46,7 +61,7 @@ public class Base64EncodedVerifierWithChooserByPublicKeyIdImpl implements Base64
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -56,7 +71,7 @@ public class Base64EncodedVerifierWithChooserByPublicKeyIdImpl implements Base64
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -66,7 +81,7 @@ public class Base64EncodedVerifierWithChooserByPublicKeyIdImpl implements Base64
 	/**
 	 * Verifies the authenticity of a message using a base64 encoded digital
 	 * signature.
-	 * 
+	 *
 	 * @param publicKeyId the logical name of the public key as configured in
 	 *        the underlying mapping
 	 * @param message the original message to verify

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChoosersByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChoosersByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PublicKeyChooserByAlias;

--- a/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChoosersByAliasImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Base64EncodedVerifierWithChoosersByAliasImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PublicKey;
@@ -12,7 +27,7 @@ import com.springcryptoutils.core.keystore.KeyStoreChooser;
  * The default implementation for verifying the authenticity of messages using
  * base64 encoded digital signatures when the public key alias can be configured
  * on the side of the user of this interface.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class Base64EncodedVerifierWithChoosersByAliasImpl implements Base64EncodedVerifierWithChoosersByAlias {
@@ -29,7 +44,7 @@ public class Base64EncodedVerifierWithChoosersByAliasImpl implements Base64Encod
 
 	/**
 	 * Sets the public key registry.
-	 * 
+	 *
 	 * @param publicKeyRegistryByAlias the public key registry
 	 */
 	public void setPublicKeyRegistryByAlias(PublicKeyRegistryByAlias publicKeyRegistryByAlias) {
@@ -38,7 +53,7 @@ public class Base64EncodedVerifierWithChoosersByAliasImpl implements Base64Encod
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -48,7 +63,7 @@ public class Base64EncodedVerifierWithChoosersByAliasImpl implements Base64Encod
 	/**
 	 * The charset to use when converting a string into a raw byte array
 	 * representation. The default is UTF-8.
-	 * 
+	 *
 	 * @param charsetName the charset name (default: UTF-8)
 	 */
 	public void setCharsetName(String charsetName) {
@@ -58,7 +73,7 @@ public class Base64EncodedVerifierWithChoosersByAliasImpl implements Base64Encod
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -68,7 +83,7 @@ public class Base64EncodedVerifierWithChoosersByAliasImpl implements Base64Encod
 	/**
 	 * Verifies the authenticity of a message using a base64 encoded digital
 	 * signature.
-	 * 
+	 *
 	 * @param keyStoreChooser the keystore chooser
 	 * @param publicKeyChooserByAlias the public key chooser
 	 * @param message the message to sign

--- a/src/main/java/com/springcryptoutils/core/signature/SignatureException.java
+++ b/src/main/java/com/springcryptoutils/core/signature/SignatureException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/Signer.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Signer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/SignerImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/SignerImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PrivateKey;
@@ -5,7 +20,7 @@ import java.security.Signature;
 
 /**
  * The default implementation for providing digital signatures.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class SignerImpl implements Signer {
@@ -18,7 +33,7 @@ public class SignerImpl implements Signer {
 
 	/**
 	 * The private key for signing the message.
-	 * 
+	 *
 	 * @param privateKey the private key
 	 */
 	public void setPrivateKey(PrivateKey privateKey) {
@@ -27,7 +42,7 @@ public class SignerImpl implements Signer {
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -37,7 +52,7 @@ public class SignerImpl implements Signer {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -46,7 +61,7 @@ public class SignerImpl implements Signer {
 
 	/**
 	 * Signs a message.
-	 * 
+	 *
 	 * @param message the message to sign
 	 * @return the signature
 	 */

--- a/src/main/java/com/springcryptoutils/core/signature/SignerWithChooserByPrivateKeyId.java
+++ b/src/main/java/com/springcryptoutils/core/signature/SignerWithChooserByPrivateKeyId.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/SignerWithChooserByPrivateKeyIdImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/SignerWithChooserByPrivateKeyIdImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PrivateKey;
@@ -7,7 +22,7 @@ import java.util.Map;
 /**
  * The default implementation for providing digital signatures when the private
  * key is configured in an underlying mapping using a logical name.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class SignerWithChooserByPrivateKeyIdImpl implements SignerWithChooserByPrivateKeyId {
@@ -22,7 +37,7 @@ public class SignerWithChooserByPrivateKeyIdImpl implements SignerWithChooserByP
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -32,7 +47,7 @@ public class SignerWithChooserByPrivateKeyIdImpl implements SignerWithChooserByP
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -42,7 +57,7 @@ public class SignerWithChooserByPrivateKeyIdImpl implements SignerWithChooserByP
 	/**
 	 * The map of private keys where the map keys are logical names which must
 	 * match the privateKeyId parameter as specified in the sign method.
-	 * 
+	 *
 	 * @param privateKeyMap the private key map
 	 * @see #sign(String, byte[])
 	 */
@@ -52,7 +67,7 @@ public class SignerWithChooserByPrivateKeyIdImpl implements SignerWithChooserByP
 
 	/**
 	 * Signs a message.
-	 * 
+	 *
 	 * @param privateKeyId the logical name of the private key as configured in
 	 *        the private key map
 	 * @param message the message to sign

--- a/src/main/java/com/springcryptoutils/core/signature/SignerWithChoosersByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/signature/SignerWithChoosersByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PrivateKeyChooserByAlias;

--- a/src/main/java/com/springcryptoutils/core/signature/SignerWithChoosersByAliasImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/SignerWithChoosersByAliasImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PrivateKey;
@@ -11,7 +26,7 @@ import com.springcryptoutils.core.keystore.KeyStoreChooser;
 /**
  * The default implementation for providing digital signatures when the private
  * key alias can be configured on the side of the user of this class.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class SignerWithChoosersByAliasImpl implements SignerWithChoosersByAlias {
@@ -26,7 +41,7 @@ public class SignerWithChoosersByAliasImpl implements SignerWithChoosersByAlias 
 
 	/**
 	 * Sets the private key registry by alias.
-	 * 
+	 *
 	 * @param privateKeyRegistryByAlias the private key registry by alias
 	 */
 	public void setPrivateKeyRegistryByAlias(PrivateKeyRegistryByAlias privateKeyRegistryByAlias) {
@@ -35,7 +50,7 @@ public class SignerWithChoosersByAliasImpl implements SignerWithChoosersByAlias 
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -45,7 +60,7 @@ public class SignerWithChoosersByAliasImpl implements SignerWithChoosersByAlias 
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -54,7 +69,7 @@ public class SignerWithChoosersByAliasImpl implements SignerWithChoosersByAlias 
 
 	/**
 	 * Signs a message.
-	 * 
+	 *
 	 * @param keyStoreChooser the keystore chooser
 	 * @param privateKeyChooserByAlias the private key chooser
 	 * @param message the message to sign

--- a/src/main/java/com/springcryptoutils/core/signature/Verifier.java
+++ b/src/main/java/com/springcryptoutils/core/signature/Verifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/VerifierImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/VerifierImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PublicKey;
@@ -6,7 +21,7 @@ import java.security.Signature;
 /**
  * The default implementation for verifying the authenticity of messages using
  * digital signatures.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class VerifierImpl implements Verifier {
@@ -19,7 +34,7 @@ public class VerifierImpl implements Verifier {
 
 	/**
 	 * The public key for verifying the message.
-	 * 
+	 *
 	 * @param publicKey the public key
 	 */
 	public void setPublicKey(PublicKey publicKey) {
@@ -28,7 +43,7 @@ public class VerifierImpl implements Verifier {
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -38,7 +53,7 @@ public class VerifierImpl implements Verifier {
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -47,7 +62,7 @@ public class VerifierImpl implements Verifier {
 
 	/**
 	 * Verifies the authenticity of a message using a digital signature.
-	 * 
+	 *
 	 * @param message the original message to verify
 	 * @param signature the digital signature
 	 * @return true if the original message is verified by the digital signature

--- a/src/main/java/com/springcryptoutils/core/signature/VerifierWithChooserByPublicKeyId.java
+++ b/src/main/java/com/springcryptoutils/core/signature/VerifierWithChooserByPublicKeyId.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 /**

--- a/src/main/java/com/springcryptoutils/core/signature/VerifierWithChooserByPublicKeyIdImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/VerifierWithChooserByPublicKeyIdImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PublicKey;
@@ -8,7 +23,7 @@ import java.util.Map;
  * The default implementation for verifying the authenticity of messages using
  * digital signatures when the public key is configured in an underlying mapping
  * using a logical name.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class VerifierWithChooserByPublicKeyIdImpl implements VerifierWithChooserByPublicKeyId {
@@ -23,7 +38,7 @@ public class VerifierWithChooserByPublicKeyIdImpl implements VerifierWithChooser
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -33,7 +48,7 @@ public class VerifierWithChooserByPublicKeyIdImpl implements VerifierWithChooser
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -43,7 +58,7 @@ public class VerifierWithChooserByPublicKeyIdImpl implements VerifierWithChooser
 	/**
 	 * The map of public keys where the map keys are logical names which must
 	 * match the publicKeyId parameter as specified in the verify method.
-	 * 
+	 *
 	 * @param publicKeyMap the public key map
 	 * @see #verify(String, byte[], byte[])
 	 */
@@ -53,7 +68,7 @@ public class VerifierWithChooserByPublicKeyIdImpl implements VerifierWithChooser
 
 	/**
 	 * Verifies the authenticity of a message using a digital signature.
-	 * 
+	 *
 	 * @param publicKeyId the logical name of the public key as configured in
 	 *        the public key map
 	 * @param message the original message to verify

--- a/src/main/java/com/springcryptoutils/core/signature/VerifierWithChoosersByAlias.java
+++ b/src/main/java/com/springcryptoutils/core/signature/VerifierWithChoosersByAlias.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PublicKeyChooserByAlias;

--- a/src/main/java/com/springcryptoutils/core/signature/VerifierWithChoosersByAliasImpl.java
+++ b/src/main/java/com/springcryptoutils/core/signature/VerifierWithChoosersByAliasImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import java.security.PublicKey;
@@ -12,7 +27,7 @@ import com.springcryptoutils.core.keystore.KeyStoreChooser;
  * The default implementation for verifying the authenticity of messages using
  * digital signatures when the public key alias can be configured on the side of
  * the user of this class.
- * 
+ *
  * @author Mirko Caserta (mirko.caserta@gmail.com)
  */
 public class VerifierWithChoosersByAliasImpl implements VerifierWithChoosersByAlias {
@@ -27,7 +42,7 @@ public class VerifierWithChoosersByAliasImpl implements VerifierWithChoosersByAl
 
 	/**
 	 * Sets the public key registry.
-	 * 
+	 *
 	 * @param publicKeyRegistryByAlias the public key registry
 	 */
 	public void setPublicKeyRegistryByAlias(PublicKeyRegistryByAlias publicKeyRegistryByAlias) {
@@ -36,7 +51,7 @@ public class VerifierWithChoosersByAliasImpl implements VerifierWithChoosersByAl
 
 	/**
 	 * The signature algorithm. The default is SHA1withRSA.
-	 * 
+	 *
 	 * @param algorithm the signature algorithm
 	 */
 	public void setAlgorithm(String algorithm) {
@@ -46,7 +61,7 @@ public class VerifierWithChoosersByAliasImpl implements VerifierWithChoosersByAl
 	/**
 	 * Sets the provider name of the specific implementation requested (e.g.,
 	 * "BC" for BouncyCastle, "SunJCE" for the default Sun JCE provider).
-	 * 
+	 *
 	 * @param provider the provider to set
 	 */
 	public void setProvider(String provider) {
@@ -55,7 +70,7 @@ public class VerifierWithChoosersByAliasImpl implements VerifierWithChoosersByAl
 
 	/**
 	 * Verifies the authenticity of a message using a digital signature.
-	 * 
+	 *
 	 * @param keyStoreChooser the keystore chooser
 	 * @param publicKeyChooserByAlias the public key chooser
 	 * @param message the message to sign

--- a/src/main/java/com/springcryptoutils/core/signature/package-info.java
+++ b/src/main/java/com/springcryptoutils/core/signature/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Interfaces and classes for performing message authentication
  * using digital signatures.

--- a/src/main/java/com/springcryptoutils/core/spring/SpringCryptoUtilsNamespaceHandler.java
+++ b/src/main/java/com/springcryptoutils/core/spring/SpringCryptoUtilsNamespaceHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring;
 
 import com.springcryptoutils.core.spring.certificate.CertificateBeanDefinitionParser;

--- a/src/main/java/com/springcryptoutils/core/spring/certificate/CertificateBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/certificate/CertificateBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.certificate;
 
 import com.springcryptoutils.core.certificate.CertificateFactoryBean;

--- a/src/main/java/com/springcryptoutils/core/spring/certificate/CertificateRegistryByAliasBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/certificate/CertificateRegistryByAliasBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.certificate;
 
 import com.springcryptoutils.core.certificate.CertificateRegistryByAliasImpl;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/AsymmetricCiphererBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/AsymmetricCiphererBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.asymmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/AsymmetricCiphererWithChooserByKeyIdBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/AsymmetricCiphererWithChooserByKeyIdBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.asymmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/Base64EncodedAsymmetricCiphererBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/Base64EncodedAsymmetricCiphererBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.asymmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/Base64EncodedAsymmetricCiphererWithChooserByKeyIdBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/asymmetric/Base64EncodedAsymmetricCiphererWithChooserByKeyIdBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.asymmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/Base64EncodedSymmetricCiphererBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/Base64EncodedSymmetricCiphererBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.symmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/Base64EncodedSymmetricCiphererWithStaticKeyBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/Base64EncodedSymmetricCiphererWithStaticKeyBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.symmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/Base64EncodedSymmetricKeyGeneratorBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/Base64EncodedSymmetricKeyGeneratorBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.symmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/SymmetricCiphererBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/SymmetricCiphererBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.symmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/SymmetricCiphererWithStaticKeyBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/SymmetricCiphererWithStaticKeyBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.symmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/SymmetricKeyGeneratorBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/cipher/symmetric/SymmetricKeyGeneratorBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.cipher.symmetric;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/digest/DigesterBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/digest/DigesterBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.digest;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/key/PrivateKeyBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/key/PrivateKeyBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.key;
 
 import com.springcryptoutils.core.key.PrivateKeyFactoryBean;

--- a/src/main/java/com/springcryptoutils/core/spring/key/PrivateKeyRegistryByAliasBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/key/PrivateKeyRegistryByAliasBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.key;
 
 import com.springcryptoutils.core.key.PrivateKeyRegistryByAliasImpl;

--- a/src/main/java/com/springcryptoutils/core/spring/key/PublicKeyBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/key/PublicKeyBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.key;
 
 import com.springcryptoutils.core.key.PublicKeyFactoryBean;

--- a/src/main/java/com/springcryptoutils/core/spring/key/PublicKeyRegistryByAliasBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/key/PublicKeyRegistryByAliasBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.key;
 
 import com.springcryptoutils.core.key.PublicKeyRegistryByAliasImpl;

--- a/src/main/java/com/springcryptoutils/core/spring/key/SecretKeyBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/key/SecretKeyBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.key;
 
 import com.springcryptoutils.core.key.PrivateKeyFactoryBean;

--- a/src/main/java/com/springcryptoutils/core/spring/keystore/Base64EncodedKeyStoreBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/keystore/Base64EncodedKeyStoreBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.keystore;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/keystore/DefaultKeyStoreBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/keystore/DefaultKeyStoreBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.keystore;
 
 import com.springcryptoutils.core.keystore.DefaultKeyStoreFactoryBean;

--- a/src/main/java/com/springcryptoutils/core/spring/keystore/KeyStoreBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/keystore/KeyStoreBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.keystore;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/keystore/KeyStoreRegistryBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/keystore/KeyStoreRegistryBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.keystore;
 
 import com.springcryptoutils.core.keystore.KeyStoreRegistryImpl;

--- a/src/main/java/com/springcryptoutils/core/spring/mac/Base64EncodedMacBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/mac/Base64EncodedMacBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.mac;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/mac/MacBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/mac/MacBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.mac;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedSignerBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedSignerBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import com.springcryptoutils.core.signature.Base64EncodedSignerImpl;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedSignerWithChooserByPrivateKeyIdBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedSignerWithChooserByPrivateKeyIdBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedSignerWithChoosersByAliasBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedSignerWithChoosersByAliasBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedVerifierBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedVerifierBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedVerifierWithChooserByPublicKeyIdBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedVerifierWithChooserByPublicKeyIdBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedVerifierWithChoosersByAliasBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/Base64EncodedVerifierWithChoosersByAliasBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/SignerBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/SignerBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/SignerWithChooserByPrivateKeyIdBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/SignerWithChooserByPrivateKeyIdBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/SignerWithChoosersByAliasBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/SignerWithChoosersByAliasBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/VerifierBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/VerifierBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/VerifierWithChooserByPublicKeyIdBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/VerifierWithChooserByPublicKeyIdBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/java/com/springcryptoutils/core/spring/signature/VerifierWithChoosersByAliasBeanDefinitionParser.java
+++ b/src/main/java/com/springcryptoutils/core/spring/signature/VerifierWithChoosersByAliasBeanDefinitionParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.spring.signature;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;

--- a/src/main/resources/com/springcryptoutils/core/spring/crypt.xsd
+++ b/src/main/resources/com/springcryptoutils/core/spring/crypt.xsd
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <xsd:schema xmlns="http://springcryptoutils.com/schema/crypt"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:beans="http://www.springframework.org/schema/beans"

--- a/src/test/java/com/springcryptoutils/core/certificate/CertificateFactoryBeanExceptionTest.java
+++ b/src/test/java/com/springcryptoutils/core/certificate/CertificateFactoryBeanExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/certificate/CertificateFactoryBeanTest.java
+++ b/src/test/java/com/springcryptoutils/core/certificate/CertificateFactoryBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/certificate/CertificateRegistryByAliasImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/certificate/CertificateRegistryByAliasImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.certificate;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdSpecificProviderImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdSpecificProviderImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.asymmetric;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.cipher.symmetric;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.digest;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeTest.java
+++ b/src/test/java/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.digest;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/digest/DigesterImplInHexOutputModeTest.java
+++ b/src/test/java/com/springcryptoutils/core/digest/DigesterImplInHexOutputModeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.digest;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/key/PrivateKeyFactoryBeanIssue5Test.java
+++ b/src/test/java/com/springcryptoutils/core/key/PrivateKeyFactoryBeanIssue5Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/key/PrivateKeyFactoryBeanTest.java
+++ b/src/test/java/com/springcryptoutils/core/key/PrivateKeyFactoryBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/key/PrivateKeyRegistryByAliasImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/key/PrivateKeyRegistryByAliasImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/test/java/com/springcryptoutils/core/key/PublicKeyFactoryBeanIssue5Test.java
+++ b/src/test/java/com/springcryptoutils/core/key/PublicKeyFactoryBeanIssue5Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/key/PublicKeyFactoryBeanTest.java
+++ b/src/test/java/com/springcryptoutils/core/key/PublicKeyFactoryBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/key/PublicKeyRegistryByAliasImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/key/PublicKeyRegistryByAliasImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import com.springcryptoutils.core.keystore.KeyStoreChooser;

--- a/src/test/java/com/springcryptoutils/core/key/SecretKeyFactoryBeanExceptionTest.java
+++ b/src/test/java/com/springcryptoutils/core/key/SecretKeyFactoryBeanExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/key/SecretKeyFactoryBeanTest.java
+++ b/src/test/java/com/springcryptoutils/core/key/SecretKeyFactoryBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.key;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBeanInitializationExceptionTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBeanInitializationExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBeanTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import org.junit.Before;
@@ -24,7 +39,7 @@ public class DefaultKeyStoreFactoryBeanTest {
 
         ctx = new ClassPathXmlApplicationContext("classpath:com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBeanTest-context.xml");
     }
-    
+
     @Test
     public void testKeyStoreIsProperlyLoaded() {
         KeyStore keyStore = ctx.getBean(KeyStore.class);

--- a/src/test/java/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanSpecifyProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanSpecifyProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/springcryptoutils/core/keystore/KeyStoreMapperImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/KeyStoreMapperImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/keystore/KeyStoreRegistryImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/keystore/KeyStoreRegistryImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.keystore;
 
 import org.junit.Test;

--- a/src/test/java/com/springcryptoutils/core/mac/Base64EncodedMacImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/mac/Base64EncodedMacImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 import org.apache.commons.codec.binary.Base64;
@@ -22,7 +37,7 @@ public class Base64EncodedMacImplSpecificProviderTest {
 
     @Autowired
     private Base64EncodedMac mac;
-    
+
     @Test
     public void testDigest() throws Exception {
         assertNotNull("mac", mac);

--- a/src/test/java/com/springcryptoutils/core/mac/Base64EncodedMacImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/mac/Base64EncodedMacImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 import org.apache.commons.codec.binary.Base64;
@@ -15,7 +30,7 @@ public class Base64EncodedMacImplTest {
 
     @Autowired
     private Base64EncodedMac mac;
-    
+
     @Test
     public void testDigest() throws Exception {
         assertNotNull("mac", mac);

--- a/src/test/java/com/springcryptoutils/core/mac/MacImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/mac/MacImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -21,7 +36,7 @@ public class MacImplSpecificProviderTest {
 
     @Autowired
     private Mac mac;
-    
+
     @Test
     public void testDigest() throws Exception {
         assertNotNull("mac", mac);

--- a/src/test/java/com/springcryptoutils/core/mac/MacImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/mac/MacImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.mac;
 
 import org.junit.Test;
@@ -14,7 +29,7 @@ public class MacImplTest {
 
     @Autowired
     private Mac mac;
-    
+
     @Test
     public void testDigest() throws Exception {
         assertNotNull("mac", mac);

--- a/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PrivateKeyChooserByAlias;

--- a/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PrivateKeyChooserByAlias;

--- a/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.junit.Before;

--- a/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PrivateKeyChooserByAlias;

--- a/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import com.springcryptoutils.core.key.PrivateKeyChooserByAlias;

--- a/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplTest.java
+++ b/src/test/java/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012 Mirko Caserta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.springcryptoutils.core.signature;
 
 import org.junit.Before;

--- a/src/test/resources/com/springcryptoutils/core/certificate/CertificateFactoryBeanExceptionTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/certificate/CertificateFactoryBeanExceptionTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/certificate/CertificateFactoryBeanTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/certificate/CertificateFactoryBeanTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/certificate/CertificateRegistryByAliasImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/certificate/CertificateRegistryByAliasImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdSpecificProviderImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/Base64EncodedCiphererWithChooserByKeyIdSpecificProviderImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/asymmetric/CiphererWithChooserByKeyIdImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedCiphererWithStaticKeyImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/Base64EncodedKeyGeneratorImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/CiphererWithStaticKeyImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/cipher/symmetric/KeyGeneratorImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/digest/DigesterImplInBase64OutputModeTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/digest/DigesterImplInHexOutputModeTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/digest/DigesterImplInHexOutputModeTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/PrivateKeyFactoryBeanIssue5Test-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/PrivateKeyFactoryBeanIssue5Test-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/PrivateKeyFactoryBeanTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/PrivateKeyFactoryBeanTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/PrivateKeyRegistryByAliasImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/PrivateKeyRegistryByAliasImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/PublicKeyFactoryBeanIssue5Test-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/PublicKeyFactoryBeanIssue5Test-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/PublicKeyFactoryBeanTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/PublicKeyFactoryBeanTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/PublicKeyRegistryByAliasImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/PublicKeyRegistryByAliasImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/SecretKeyFactoryBeanExceptionTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/SecretKeyFactoryBeanExceptionTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/key/SecretKeyFactoryBeanTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/key/SecretKeyFactoryBeanTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/keystore/Base64EncodedKeyStoreFactoryBeanTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBeanTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/keystore/DefaultKeyStoreFactoryBeanTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanSpecifyProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanSpecifyProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreFactoryBeanTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreMapperImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreMapperImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreRegistryImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/keystore/KeyStoreRegistryImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/mac/Base64EncodedMacImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/mac/Base64EncodedMacImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/mac/Base64EncodedMacImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/mac/Base64EncodedMacImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/mac/MacImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/mac/MacImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/mac/MacImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/mac/MacImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByAliasImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/Base64EncodedSignerAndVerifierWithChoosersByKeyIdImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByAliasImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplSpecificProviderTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"

--- a/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplTest-context.xml
+++ b/src/test/resources/com/springcryptoutils/core/signature/SignerAndVerifierWithChoosersByKeyIdImplTest-context.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ | Copyright 2012 Mirko Caserta
+ |
+ | Licensed under the Apache License, Version 2.0 (the "License");
+ | you may not use this software except in compliance with the License.
+ | You may obtain a copy of the License at
+ |
+ |  http://www.apache.org/licenses/LICENSE-2.0
+ |
+ | Unless required by applicable law or agreed to in writing, software
+ | distributed under the License is distributed on an "AS IS" BASIS,
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ | See the License for the specific language governing permissions and
+ | limitations under the License.
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
        xmlns:crypt="http://springcryptoutils.com/schema/crypt"


### PR DESCRIPTION
My poor-man contribution to the project: the proposed pull request contains a better appliance of the Apache License v2, compliant to what we do at the ASF:
- each file contains the right license header;
- LICENSE file contains the full text of the ALv2
- Added missing NOTICE file
- LICENSE & NOTICE files included in the final artifacts, under META-INF dir

HTH,
-Simo
